### PR TITLE
fix: 45 min limit error

### DIFF
--- a/actions/test.go
+++ b/actions/test.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -241,6 +242,16 @@ func TestPost(c buffalo.Context) error {
 	if postTestrequestModel.EnvironmentMatrix.IosDeviceList != nil {
 		if err := firebaseutils.ValidateIosDevices(postTestrequestModel.EnvironmentMatrix.IosDeviceList.IosDevices); err != nil {
 			return c.Render(http.StatusNotAcceptable, r.String("Invalid device configuration: %s", err))
+		}
+	}
+
+	if timeout := postTestrequestModel.TestSpecification.TestTimeout; timeout != "" {
+		secs, err := strconv.ParseFloat(strings.TrimSuffix(timeout, "s"), 32)
+		if err == nil {
+			if int(secs) > 2700 {
+				logger.Warn("Incoming TestSpecification.TestTimeout '%s' exceeds limit of '2700s', overriding")
+				postTestrequestModel.TestSpecification.TestTimeout = "2700s"
+			}
 		}
 	}
 

--- a/actions/test.go
+++ b/actions/test.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -248,8 +249,8 @@ func TestPost(c buffalo.Context) error {
 	if timeout := postTestrequestModel.TestSpecification.TestTimeout; timeout != "" {
 		secs, err := strconv.ParseFloat(strings.TrimSuffix(timeout, "s"), 32)
 		if err == nil {
-			if int(secs) > 2700 {
-				logger.Warn("Incoming TestSpecification.TestTimeout '%s' exceeds limit of '2700s', overriding")
+			if secs > 2700.0 {
+				logger.Warn(fmt.Sprintf("Incoming TestSpecification.TestTimeout '%s' from build '%s' exceeds limit of '2700s', overriding it to '2700s'", timeout, appSlug))
 				postTestrequestModel.TestSpecification.TestTimeout = "2700s"
 			}
 		}


### PR DESCRIPTION
Google seems to have changed to maximum timeout limit to 45 mins for tests and users keep getting errors.

Because users not updating their VDT steps will not be able to receive the fix in the step, we decided we will implement an override logic in the backend.