### PR TITLE
[NOJIRA] pin buffalo version using go module install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN go get github.com/codegangsta/gin \
     && go get github.com/kisielk/errcheck \
     && go get golang.org/x/lint/golint \
     && go get github.com/stripe/safesql \
-    && go get github.com/gobuffalo/buffalo/buffalo
+    && GO111MODULE=on go get github.com/gobuffalo/buffalo/buffalo@v0.15.1
 
 RUN apt-get update -qq && apt-get upgrade -y && \
     apt-get install -y postgresql-client

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,10 +1,10 @@
-FROM golang:1.11
+FROM golang:1.13
 
 RUN apt-get update -qq && apt-get upgrade -y && \
     apt-get install -y postgresql-client sqlite3
 
-RUN go get -v -u github.com/gobuffalo/buffalo/buffalo
-RUN go get -v -u github.com/gobuffalo/buffalo-pop
+RUN GO111MODULE=on go get -v -u github.com/gobuffalo/buffalo/buffalo@v0.15.1
+RUN GO111MODULE=on go get -v -u github.com/gobuffalo/buffalo-pop@v1.23.1
 
 COPY . /go/src/github.com/bitrise-io/addons-firebase-testlab/
 RUN cd /go/src/github.com/bitrise-io/addons-firebase-testlab/ && \

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,10 +1,10 @@
-FROM golang:1.11
+FROM golang:1.13
 
 RUN apt-get update -qq && apt-get upgrade -y && \
     apt-get install -y postgresql-client sqlite3
 
-RUN go get -v -u github.com/gobuffalo/buffalo/buffalo
-RUN go get -v -u github.com/gobuffalo/buffalo-pop
+RUN GO111MODULE=on go get -v -u github.com/gobuffalo/buffalo/buffalo@v0.15.1
+RUN GO111MODULE=on go get -v -u github.com/gobuffalo/buffalo-pop@v1.23.1
 
 COPY . /go/src/github.com/bitrise-io/addons-firebase-testlab/
 RUN cd /go/src/github.com/bitrise-io/addons-firebase-testlab/ && \


### PR DESCRIPTION
Latest buffalo install did not work due to a peer dependency issue (see: https://github.com/gobuffalo/genny/issues/36). In order to resolve this I pinned down buffalo dependency to install it.